### PR TITLE
Printer room addon v1.0.4

### DIFF
--- a/rooms/plant/button.yaml
+++ b/rooms/plant/button.yaml
@@ -13,6 +13,20 @@ tap_action:
   navigation_path: {{ navigation_path }}
 label: >
   [[[
+  {% if (data | fromjson)['plants']|length > 1 %}
+    var problemPlants = 0;
+
+    {% for plants in (data | fromjson)['plants'] %}
+      var state = states['{{plants.entity}}'].state
+      if (state == 'problem')
+        problemPlants++;
+    {% endfor %}
+    if(problemPlants > 0){
+      return problemPlants + ' ' + hass.localize('component.binary_sensor.state.problem.on');
+    } else {
+      return '&nbsp;';
+    }
+  {% else %}
     if (entity.state == 'ok') {
       return hass.localize('component.plant.state._.ok');
     } else if (entity.state == 'problem') {
@@ -20,4 +34,5 @@ label: >
     } else {
       return 'Entity error!';
     }
+  {% endif %}
   ]]]

--- a/rooms/printer/README.md
+++ b/rooms/printer/README.md
@@ -23,11 +23,30 @@ To use this add-on in your Dwains Theme, add the following to your `custom_resou
   - name: Office
     addons:
       - name: Printer
-        icon: fas:print
+        icon: mdi:printer
         path: 'dwains-theme/addons/rooms/office/printer/page.yaml'
         button_path: 'dwains-theme/addons/rooms/office/printer/button.yaml'
         data:
-          entity: sensor.hp_printer_status
+          printer:
+            - entity: sensor.hp_m281fdw_status
+              name: State
+            - entity: sensor.hp_m281fdw_printer
+              name: Total printed pages
+            - entity: sensor.hp_m281fdw_scanner
+              name: Total scanned pages
+          cardridges:
+            - entity: sensor.hp_m281fdw_toner_black
+              name: Zwart
+              color: Black
+            - entity: sensor.hp_m281fdw_toner_cyan
+              name: Cyaan
+              color: MediumTurquoise
+            - entity: sensor.hp_m281fdw_toner_magenta
+              name: Magenta
+              color: MediumOrchid
+            - entity: sensor.hp_m281fdw_toner_yellow
+              name: Geel
+              color: Gold
 ```
 
 ### Screenshots
@@ -39,6 +58,8 @@ To use this add-on in your Dwains Theme, add the following to your `custom_resou
 
 
 ### Changelog
+#### 1.0.4
+- **BREAKING CHANGE**: ***The addon is now more dynamic than ever!*** You can add all your printer entites and cardridges via the `rooms.yaml` file. *Make sure you overwrite both the button.yaml and the page.yaml file when you update to the newest version of the addon*
 #### 1.0.3
 - Add border-radius to bar-cards + CSS style cleanup
 #### 1.0.2

--- a/rooms/printer/button.yaml
+++ b/rooms/printer/button.yaml
@@ -1,13 +1,13 @@
 # dwains_theme
 ## Custom button for room add-on: Printer
 ## Created by Jeroen Klompen
-## Version: 1.0.3
+## Version: 1.0.4
 
 type: custom:button-card
-entity: {{ (data | fromjson)['entity'] }}
+entity: {{ (data | fromjson)['printer'][0].entity }}
 template: rooms_child
 name: {{ name }}
-icon: {{ icon|default('fas:puzzle-piece') }}
+icon: {{ icon|default('mdi:printer') }}
 tap_action:
   action: navigate
   navigation_path: {{ navigation_path }}

--- a/rooms/printer/page.yaml
+++ b/rooms/printer/page.yaml
@@ -13,12 +13,7 @@
           background-color: var(--dwains-theme-primary);
         }
       entities:
-      {% for printer in (data | fromjson)['printer'] %}
-        - entity: {{ printer.entity }}
-        {% if printer.name %}
-          name: {{ printer.name }}
-        {% endif %}
-      {% endfor %}
+        {{ (data | fromjson)['printer'] }}
 
     - type: 'custom:bar-card'
       style: |

--- a/rooms/printer/page.yaml
+++ b/rooms/printer/page.yaml
@@ -1,10 +1,10 @@
+# dwains_theme
 ## Created by Jeroen Klompen
 ## Room add-on: Printer
-## Version: 1.0.3
+## Version: 1.0.4
 
 - type: custom:dwains-flexbox-card
   items_classes: 'col-xs-12 col-sm-6 col-sm-6'
-  #padding: true
   cards:
     - type: entities
       style: |
@@ -13,14 +13,12 @@
           background-color: var(--dwains-theme-primary);
         }
       entities:
-        - entity: sensor.hp_m281fdw_status
-          name: Status
-        - entity: sensor.hp_m281fdw_printer
-          icon: mdi:printer
-          name: "Totaal aantal pagina's afgedrukt"
-        - entity: sensor.hp_m281fdw_scanner
-          icon: mdi:printer
-          name: "Totaal aantal pagina's gescand"
+      {% for printer in (data | fromjson)['printer'] %}
+        - entity: {{ printer.entity }}
+        {% if printer.name %}
+          name: {{ printer.name }}
+        {% endif %}
+      {% endfor %}
 
     - type: 'custom:bar-card'
       style: |
@@ -56,19 +54,11 @@
       unit_of_measurement: '%'
       width: 100%
       entities:
-        - entity: sensor.hp_m281fdw_toner_black
-          name: Zwart
-          color: Black
+      {% for cardridges in (data | fromjson)['cardridges'] %}
+        - entity: {{ cardridges.entity }}
+        {% if cardridges.name %}
+          name: {{ cardridges.name }}
+        {% endif %}
+          color: {{ cardridges.color }}
           icon: mdi:water
-        - entity: sensor.hp_m281fdw_toner_cyan
-          name: Cyaan
-          color: MediumTurquoise
-          icon: mdi:water
-        - entity: sensor.hp_m281fdw_toner_magenta
-          name: Magenta
-          color: MediumOrchid
-          icon: mdi:water
-        - entity: sensor.hp_m281fdw_toner_yellow
-          name: Geel
-          color: Gold
-          icon: mdi:water
+      {% endfor %}


### PR DESCRIPTION
#### Printer room addon v1.0.4
- **BREAKING CHANGE**: ***The addon is now more dynamic than ever!*** You can add all your printer entites and cardridges via the `rooms.yaml` file. *Make sure you overwrite both the button.yaml and the page.yaml file when you update to the newest version of the addon*