### PR TITLE
Wrong Parameters in zone_ids

### DIFF
--- a/rooms/vacuum/page.yaml
+++ b/rooms/vacuum/page.yaml
@@ -48,12 +48,12 @@
               entity_id: {{ (data | fromjson)['vacuum'] }}
               command: zoned_cleanup
               params:
-                'zone_ids': ['{{ rooms.zone }}']
+                'zone_ids': ['{{ rooms.room }}']
             {% else %}
             service_data:
               entity_id: {{ (data | fromjson)['vacuum'] }}
               command: app_zoned_clean
-              params: ['{{ rooms.zone }}']
+              params: ['{{ rooms.room }}']
             {% endif %}
           styles:
             grid:


### PR DESCRIPTION
As we configure our addon  in rooms like:
      - name: Vacuum
        icon: mdi:robot-vacuum
        path: "dwains-dashboard/addons/rooms/livingroom/vacuum/page.yaml"
        button_path: "dwains-dashboard/addons/rooms/livingroom/vacuum/button.yaml"
        data:
          vacuum: vacuum.rockrobo
          platform: valetudo
          map: camera.rockrobo_map
          rooms:
            - room: Living Room
              icon: mdi:television-classic
    ........

we have to path rooms.room istead of rooms.zone